### PR TITLE
Phase 2 PR 2: CivicWeb Scraper Refactor

### DIFF
--- a/apps/pipeline/main.py
+++ b/apps/pipeline/main.py
@@ -1,10 +1,15 @@
 import argparse
 from pipeline import config
 from pipeline.paths import ARCHIVE_ROOT
-from pipeline.orchestrator import Archiver
+from pipeline.orchestrator import Archiver, load_municipality
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="View Royal CivicWeb & Vimeo Archiver")
+    parser = argparse.ArgumentParser(description="Municipal CivicWeb & Vimeo Archiver")
+
+    parser.add_argument(
+        "--municipality", type=str, default=None,
+        help="Municipality slug (e.g. 'view-royal'). Loads config from DB.",
+    )
 
     parser.add_argument(
         "--videos-only", action="store_true", help="Skip the document scanning phase."
@@ -88,10 +93,16 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
+    # Load municipality config if specified
+    municipality = None
+    if args.municipality:
+        municipality = load_municipality(args.municipality)
+        print(f"[*] Municipality: {municipality.name} ({municipality.slug})")
+
     # Use centralized ARCHIVE_ROOT as default
     output_dir = args.input_dir if args.input_dir else ARCHIVE_ROOT
 
-    app = Archiver()
+    app = Archiver(municipality=municipality)
 
     if args.target:
         # Targeted mode: diarize → ingest → embed for a single meeting

--- a/apps/pipeline/pipeline/civicweb.py
+++ b/apps/pipeline/pipeline/civicweb.py
@@ -4,17 +4,18 @@ from urllib.parse import urljoin
 from pipeline import config
 
 class CivicWebClient:
-    def __init__(self):
+    def __init__(self, base_url: str = None):
+        self.base_url = base_url or config.CIVICWEB_BASE_URL
         self.session = requests.Session()
         self.session.headers.update({
-            "User-Agent": config.USER_AGENT, 
+            "User-Agent": config.USER_AGENT,
             "Accept": "application/json"
         })
 
     def _get_api_url(self, folder_id=None):
         if folder_id is None:
-            return urljoin(config.CIVICWEB_BASE_URL, "/api/documents/getchildlist")
-        return urljoin(config.CIVICWEB_BASE_URL, f"/api/document/{folder_id}/getchildlist")
+            return urljoin(self.base_url, "/api/documents/getchildlist")
+        return urljoin(self.base_url, f"/api/document/{folder_id}/getchildlist")
 
     def _fetch_items(self, folder_id):
         page = 1

--- a/apps/pipeline/pipeline/orchestrator.py
+++ b/apps/pipeline/pipeline/orchestrator.py
@@ -4,17 +4,57 @@ import os
 from supabase import create_client
 
 from pipeline import config, parser, utils
-from pipeline.paths import ARCHIVE_ROOT
+from pipeline.paths import ARCHIVE_ROOT, get_municipality_archive_root
+from pipeline.scrapers import get_scraper, register_scraper, MunicipalityConfig
+from pipeline.scrapers.civicweb import CivicWebScraper
 
 from .local_diarizer import LocalDiarizer
-from .scrapers.civicweb import CivicWebScraper
 from .video.vimeo import VimeoClient
+
+# Register built-in scrapers
+register_scraper("civicweb", CivicWebScraper)
+
+
+def load_municipality(slug: str) -> MunicipalityConfig:
+    """Load municipality config from Supabase by slug."""
+    supabase_key = config.SUPABASE_SECRET_KEY or config.SUPABASE_KEY
+    if not config.SUPABASE_URL or not supabase_key:
+        raise RuntimeError("SUPABASE_URL/KEY not set — cannot load municipality config")
+
+    supabase = create_client(config.SUPABASE_URL, supabase_key)
+    result = (
+        supabase.table("municipalities")
+        .select("*")
+        .eq("slug", slug)
+        .single()
+        .execute()
+    )
+
+    if not result.data:
+        raise ValueError(f"Municipality not found: {slug}")
+
+    return MunicipalityConfig.from_db_row(result.data)
 
 
 class Archiver:
-    def __init__(self):
-        self.scraper = CivicWebScraper()
-        self.vimeo_client = VimeoClient()
+    def __init__(self, municipality: MunicipalityConfig | None = None):
+        if municipality is None:
+            # Backward compat: default to View Royal with hardcoded defaults
+            self.municipality = None
+            self.archive_root = ARCHIVE_ROOT
+            self.scraper = CivicWebScraper()
+            self.vimeo_client = VimeoClient()
+        else:
+            self.municipality = municipality
+            self.archive_root = get_municipality_archive_root(municipality.slug)
+            self.scraper = get_scraper(municipality)
+
+            # VimeoClient gets vimeo user from source_config
+            video_config = municipality.source_config.get("video_source", {})
+            self.vimeo_client = VimeoClient(
+                vimeo_user=video_config.get("user", "viewroyal")
+            )
+
         self.ai_enabled = False
         self.diarizer = None
 
@@ -49,8 +89,9 @@ class Archiver:
         skip_ingest=False,
         skip_embed=False,
     ):
-        print("=== View Royal Archiver ===")
-        print(f"Archive Root: {ARCHIVE_ROOT}")
+        label = self.municipality.name if self.municipality else "View Royal"
+        print(f"=== {label} Archiver ===")
+        print(f"Archive Root: {self.archive_root}")
 
         # Phase 1: Documents
         if not skip_docs and not rediarize:
@@ -68,7 +109,7 @@ class Archiver:
             if video_map:
                 print("\n--- Phase 2: Matching & Downloading Vimeo Content ---")
                 self._download_vimeo_content(
-                    video_map, include_video, download_audio, limit, ARCHIVE_ROOT
+                    video_map, include_video, download_audio, limit, self.archive_root
                 )
 
         # Phase 3: Processing
@@ -76,7 +117,7 @@ class Archiver:
         if self.ai_enabled and not skip_diarization:
             label = "Re-diarizing" if rediarize else "Diarization"
             print(f"\n--- Phase 3: Processing Audio ({label}) ---")
-            diarized_folders = self._process_audio_files(limit, ARCHIVE_ROOT, rediarize=rediarize)
+            diarized_folders = self._process_audio_files(limit, self.archive_root, rediarize=rediarize)
 
         # Phase 4: Ingestion
         if not skip_ingest:
@@ -100,8 +141,9 @@ class Archiver:
         include_video,
         download_audio,
         limit=None,
-        output_dir=ARCHIVE_ROOT,
+        output_dir=None,
     ):
+        output_dir = output_dir or self.archive_root
         matches = 0
         for root, dirs, files in os.walk(output_dir):
             folder_name = os.path.basename(root)
@@ -160,9 +202,6 @@ class Archiver:
                             )
 
                 if not video_data:
-                    # Final fallback: if we can't decide, maybe it's just one video for a joint meeting?
-                    # But if we have multiple videos and can't match, better to skip than to guess wrong.
-                    # print(f"  [!] Could not match video for {folder_name} among {len(videos)} options.")
                     continue
 
                 # Determine subfolder
@@ -187,7 +226,6 @@ class Archiver:
                     f"[Match] {date_key}: Syncing {msg} from '{video_data['title']}' to '{folder_name}/{subfolder}'"
                 )
 
-                # CHANGED: Passing the whole video_data dict, not just the url
                 new_audio_path = self.vimeo_client.download_video(
                     video_data,
                     target_dir,
@@ -197,8 +235,9 @@ class Archiver:
 
                 matches += 1
 
-    def _collect_audio_files(self, output_dir=ARCHIVE_ROOT, rediarize=False):
+    def _collect_audio_files(self, output_dir=None, rediarize=False):
         """Collect audio files that need processing."""
+        output_dir = output_dir or self.archive_root
         audio_files = []
         for root, dirs, files in os.walk(output_dir):
             for file in files:
@@ -210,7 +249,8 @@ class Archiver:
                     audio_files.append(audio_path)
         return audio_files
 
-    def _process_audio_files(self, limit=None, output_dir=ARCHIVE_ROOT, rediarize=False):
+    def _process_audio_files(self, limit=None, output_dir=None, rediarize=False):
+        output_dir = output_dir or self.archive_root
         audio_files = self._collect_audio_files(output_dir, rediarize)
 
         if limit:
@@ -346,7 +386,7 @@ class Archiver:
             print(f"  {len(diarized_folders)} meeting(s) freshly diarized.")
 
         # Walk archive and process
-        for root, dirs, files in os.walk(ARCHIVE_ROOT):
+        for root, dirs, files in os.walk(self.archive_root):
             if "Agenda" not in dirs and "Audio" not in dirs:
                 continue
 

--- a/apps/pipeline/pipeline/scrapers/civicweb.py
+++ b/apps/pipeline/pipeline/scrapers/civicweb.py
@@ -1,30 +1,51 @@
 import os
-import sys
-import time
 from urllib.parse import urljoin
-from pipeline import utils
+
+from pipeline import config, utils
 from pipeline.civicweb import CivicWebClient
-from pipeline.paths import ARCHIVE_ROOT
+from pipeline.paths import ARCHIVE_ROOT, get_municipality_archive_root
+from pipeline.scrapers.base import BaseScraper, MunicipalityConfig, ScrapedMeeting
 
-# --- Configuration ---
-BASE_URL = "https://viewroyalbc.civicweb.net"
 
-class CivicWebScraper(CivicWebClient):
-    def __init__(self):
-        super().__init__()
+class CivicWebScraper(BaseScraper, CivicWebClient):
+    """CivicWeb scraper that extends both BaseScraper and CivicWebClient."""
 
-    def download_file(self, item, top_level, parent_folder_name):
-        """
-        Downloads a single file, determining its correct archive path first.
-        """
-        title = item.get('Title', 'Untitled')
-        file_id = item.get('Id')
-        extension = item.get('Extension', '').replace('.', '')
+    def __init__(self, municipality: MunicipalityConfig | None = None):
+        if municipality is not None:
+            BaseScraper.__init__(self, municipality)
+            base_url = self.source_config.get("base_url", config.CIVICWEB_BASE_URL)
+            self.archive_root = get_municipality_archive_root(municipality.slug)
+        else:
+            # Backward compat: no municipality config, use defaults
+            self.municipality = None
+            self.source_config = {}
+            base_url = config.CIVICWEB_BASE_URL
+            self.archive_root = ARCHIVE_ROOT
+
+        CivicWebClient.__init__(self, base_url)
+
+    def discover_meetings(self, since_date=None) -> list[ScrapedMeeting]:
+        # CivicWeb discovery happens during scrape_recursive.
+        # Return empty list — CivicWeb uses download_documents directly.
+        return []
+
+    def download_documents(self, meeting=None, target_dir=None) -> list[str]:
+        archive_root = target_dir or self.archive_root
+        self.scrape_recursive(None, archive_root=archive_root)
+        return []
+
+    def download_file(self, item, top_level, parent_folder_name, archive_root=None):
+        """Downloads a single file, determining its correct archive path first."""
+        archive_root = archive_root or self.archive_root
+
+        title = item.get("Title", "Untitled")
+        file_id = item.get("Id")
+        extension = item.get("Extension", "").replace(".", "")
         if not extension:
-            extension = item.get('FileFormat', '')
+            extension = item.get("FileFormat", "")
 
         # Skip Html.docx files (redundant HTML-exported Word docs)
-        if '- Html' in title and extension.lower() == 'docx':
+        if "- Html" in title and extension.lower() == "docx":
             return
 
         # 1. Determine Correct Archive Path
@@ -37,7 +58,9 @@ class CivicWebScraper(CivicWebClient):
         if not meta["date"]:
             return
 
-        target_dir = utils.get_target_path(ARCHIVE_ROOT, top_level or "Uncategorized", meta)
+        target_dir = utils.get_target_path(
+            archive_root, top_level or "Uncategorized", meta
+        )
 
         # 2. Determine filename
         filename = utils.sanitize_filename(title)
@@ -51,52 +74,64 @@ class CivicWebScraper(CivicWebClient):
             return
 
         # 3. Download
-        download_suffix = item.get('ContentUrl')
+        download_suffix = item.get("ContentUrl")
         if not download_suffix and file_id:
             download_suffix = f"/document/{file_id}"
 
         if not download_suffix:
             return
 
-        download_url = urljoin(BASE_URL, download_suffix)
+        download_url = urljoin(self.base_url, download_suffix)
 
         if not os.path.exists(target_dir):
             os.makedirs(target_dir, exist_ok=True)
 
-        print(f"[*] Downloading: {filename} -> {os.path.relpath(target_dir, ARCHIVE_ROOT)}")
+        print(
+            f"[*] Downloading: {filename} -> {os.path.relpath(target_dir, archive_root)}"
+        )
         try:
             with self.session.get(download_url, stream=True) as r:
                 r.raise_for_status()
-                with open(file_path, 'wb') as f:
+                with open(file_path, "wb") as f:
                     for chunk in r.iter_content(chunk_size=8192):
                         f.write(chunk)
                 # Save the URL to a companion file
-                with open(f"{file_path}.url", 'w') as f:
+                with open(f"{file_path}.url", "w") as f:
                     f.write(download_url)
         except Exception as e:
             print(f"[!] Failed to download {filename}: {e}")
 
-    def scrape_recursive(self, folder_id=None, top_level=None, parent_folder_name=""):
-        """
-        Recursively processes folders.
-        """
+    def scrape_recursive(
+        self,
+        folder_id=None,
+        top_level=None,
+        parent_folder_name="",
+        archive_root=None,
+    ):
+        """Recursively processes folders."""
+        archive_root = archive_root or self.archive_root
         items = list(self._fetch_items(folder_id))
         if not items:
             return
 
         for item in items:
-            item_id = item.get('Id')
-            title = item.get('Title', 'Unknown')
-            is_folder = item.get('Folder', False)
+            item_id = item.get("Id")
+            title = item.get("Title", "Unknown")
+            is_folder = item.get("Folder", False)
 
             if is_folder:
                 current_top = top_level
                 if folder_id is None:
                     current_top = utils.normalize_top_level(title)
-                
-                self.scrape_recursive(item_id, current_top, title)
+
+                self.scrape_recursive(
+                    item_id, current_top, title, archive_root=archive_root
+                )
             else:
-                self.download_file(item, top_level, parent_folder_name)
+                self.download_file(
+                    item, top_level, parent_folder_name, archive_root=archive_root
+                )
+
 
 def run_scraper():
     print("--- CivicWeb Scraper (Archive Mode) ---")
@@ -110,6 +145,7 @@ def run_scraper():
         print("\n[!] Stopped by user.")
     except Exception as e:
         print(f"\n[!] Unexpected Error: {e}")
+
 
 if __name__ == "__main__":
     run_scraper()

--- a/apps/pipeline/pipeline/video/vimeo.py
+++ b/apps/pipeline/pipeline/video/vimeo.py
@@ -10,8 +10,9 @@ from pipeline import config, utils
 
 
 class VimeoClient:
-    def __init__(self):
+    def __init__(self, vimeo_user: str = "viewroyal"):
         self.token = config.VIMEO_ACCESS_TOKEN
+        self.vimeo_user = vimeo_user
         self.headers = {}
         # Cache to store transcript URLs {uri: url_or_none}
         self.track_url_cache = {}
@@ -33,7 +34,7 @@ class VimeoClient:
             return {}
 
         video_map = {}
-        api_url = "https://api.vimeo.com/users/viewroyal/videos"
+        api_url = f"https://api.vimeo.com/users/{self.vimeo_user}/videos"
         params = {
             "per_page": 100,
             "page": 1,
@@ -105,7 +106,7 @@ class VimeoClient:
 
         # We could use the search API, but usually fetching the latest
         # is enough for new meetings.
-        api_url = "https://api.vimeo.com/users/viewroyal/videos"
+        api_url = f"https://api.vimeo.com/users/{self.vimeo_user}/videos"
         params = {
             "per_page": 20,  # Just check recent ones
             "query": date_str,


### PR DESCRIPTION
## Summary
- Refactors `CivicWebScraper` to extend `BaseScraper` ABC with `MunicipalityConfig`-driven configuration
- Parameterizes `CivicWebClient` with `base_url` and `VimeoClient` with `vimeo_user` (no more hardcoded URLs)
- Updates `Archiver` to accept optional `MunicipalityConfig`, using scraper registry and per-municipality archive paths
- Adds `load_municipality()` helper to fetch config from Supabase `municipalities` table
- Adds `--municipality` CLI arg to `main.py` (e.g. `--municipality view-royal`)
- Full backward compatibility: `Archiver()` with no args defaults to View Royal

## Test plan
- [x] All 15 existing tests pass (1 skipped — pre-existing)
- [x] Import check: `from pipeline.scrapers.civicweb import CivicWebScraper`
- [x] Backward compat: `CivicWebScraper()` uses default CivicWeb base URL
- [x] Backward compat: `Archiver()` with no args works unchanged
- [x] `VimeoClient(vimeo_user='test')` parameterization works

🤖 Generated with [Claude Code](https://claude.com/claude-code)