### PR TITLE
Phase 2 PR 3: Legistar + Static HTML Scrapers

### DIFF
--- a/apps/pipeline/pipeline/scrapers/__init__.py
+++ b/apps/pipeline/pipeline/scrapers/__init__.py
@@ -17,3 +17,15 @@ def get_scraper(municipality: MunicipalityConfig) -> BaseScraper:
     if source_type not in SCRAPER_REGISTRY:
         raise ValueError(f"No scraper registered for source type: {source_type}")
     return SCRAPER_REGISTRY[source_type](municipality)
+
+
+def _register_builtin_scrapers():
+    """Register all built-in scraper implementations."""
+    from pipeline.scrapers.legistar import LegistarScraper
+    from pipeline.scrapers.static_html import StaticHtmlScraper
+
+    register_scraper("legistar", LegistarScraper)
+    register_scraper("static_html", StaticHtmlScraper)
+
+
+_register_builtin_scrapers()

--- a/apps/pipeline/pipeline/scrapers/legistar.py
+++ b/apps/pipeline/pipeline/scrapers/legistar.py
@@ -1,0 +1,188 @@
+"""Legistar Web API scraper for municipalities using the Legistar platform."""
+
+import os
+import time
+from datetime import date, datetime
+
+import requests
+
+from pipeline import config
+from pipeline.scrapers.base import (
+    BaseScraper,
+    MunicipalityConfig,
+    ScrapedDocument,
+    ScrapedMeeting,
+)
+
+
+class LegistarScraper(BaseScraper):
+    """Scraper for municipalities using the Legistar Web API.
+
+    Uses the public Legistar Web API (webapi.legistar.com) to discover
+    meetings and download associated documents.
+
+    Expected source_config:
+        {
+            "type": "legistar",
+            "client_id": "esquimalt",
+            "timezone": "America/Vancouver",
+            "video_source": {"type": "legistar_inline"}
+        }
+    """
+
+    API_BASE = "https://webapi.legistar.com/v1"
+
+    def __init__(self, municipality: MunicipalityConfig):
+        super().__init__(municipality)
+        self.client_id = self.source_config.get("client_id")
+        if not self.client_id:
+            raise ValueError(
+                f"Legistar scraper requires 'client_id' in source_config for {municipality.slug}"
+            )
+        self.session = requests.Session()
+        self.session.headers.update({"Accept": "application/json"})
+
+    def _api_url(self, endpoint: str) -> str:
+        return f"{self.API_BASE}/{self.client_id}/{endpoint}"
+
+    def _get(self, endpoint: str, params: dict | None = None) -> list | dict | None:
+        """Make a GET request to the Legistar API with rate limiting."""
+        url = self._api_url(endpoint)
+        try:
+            resp = self.session.get(url, params=params, timeout=config.REQUEST_TIMEOUT)
+            if resp.status_code == 404:
+                return None
+            resp.raise_for_status()
+            time.sleep(config.DELAY_BETWEEN_REQUESTS)
+            return resp.json()
+        except requests.RequestException as e:
+            print(f"  [!] Legistar API error ({endpoint}): {e}")
+            return None
+
+    def discover_meetings(
+        self, since_date: date | None = None
+    ) -> list[ScrapedMeeting]:
+        """Discover meetings from the Legistar Events API."""
+        params = {"$orderby": "EventDate desc"}
+        if since_date:
+            params["$filter"] = f"EventDate ge datetime'{since_date.isoformat()}'"
+
+        data = self._get("Events", params)
+        if not data or not isinstance(data, list):
+            return []
+
+        meetings = []
+        for event in data:
+            event_date_str = event.get("EventDate", "")
+            if not event_date_str:
+                continue
+
+            try:
+                event_date = datetime.fromisoformat(
+                    event_date_str.replace("T", " ").split("+")[0].split("Z")[0]
+                ).date()
+            except (ValueError, IndexError):
+                continue
+
+            meeting = ScrapedMeeting(
+                date=event_date,
+                title=event.get("EventBodyName", "Unknown"),
+                meeting_type=event.get("EventBodyName"),
+                organization_name=self.municipality.name,
+                agenda_url=event.get("EventAgendaFile"),
+                minutes_url=event.get("EventMinutesFile"),
+                video_url=event.get("EventVideoPath"),
+                source_id=str(event.get("EventId", "")),
+                meta={"legistar_event": event},
+            )
+
+            # Fetch event items (agenda items with attachments)
+            event_id = event.get("EventId")
+            if event_id:
+                items = self._get(f"Events/{event_id}/EventItems")
+                if items and isinstance(items, list):
+                    for item in items:
+                        item_id = item.get("EventItemId")
+                        if not item_id:
+                            continue
+
+                        attachments = self._get(
+                            f"Events/{event_id}/EventItems/{item_id}/Attachments"
+                        )
+                        if attachments and isinstance(attachments, list):
+                            for att in attachments:
+                                doc = ScrapedDocument(
+                                    title=att.get(
+                                        "MatterAttachmentName", "Untitled"
+                                    ),
+                                    url=att.get("MatterAttachmentHyperlink", ""),
+                                    category="Attachment",
+                                    file_format=att.get(
+                                        "MatterAttachmentFileName", ""
+                                    )
+                                    .rsplit(".", 1)[-1]
+                                    if "." in att.get("MatterAttachmentFileName", "")
+                                    else None,
+                                )
+                                if doc.url:
+                                    meeting.documents.append(doc)
+
+            meetings.append(meeting)
+
+        print(f"  [Legistar] Discovered {len(meetings)} meeting(s) for {self.client_id}")
+        return meetings
+
+    def download_documents(
+        self, meeting: ScrapedMeeting, target_dir: str
+    ) -> list[str]:
+        """Download meeting documents to target_dir."""
+        os.makedirs(target_dir, exist_ok=True)
+        downloaded = []
+
+        # Download agenda PDF
+        if meeting.agenda_url:
+            path = self._download_file(meeting.agenda_url, target_dir, "Agenda")
+            if path:
+                downloaded.append(path)
+
+        # Download minutes PDF
+        if meeting.minutes_url:
+            path = self._download_file(meeting.minutes_url, target_dir, "Minutes")
+            if path:
+                downloaded.append(path)
+
+        # Download attachments
+        for doc in meeting.documents:
+            if doc.url:
+                subfolder = os.path.join(target_dir, "Attachments")
+                path = self._download_file(doc.url, subfolder, doc.title)
+                if path:
+                    downloaded.append(path)
+
+        return downloaded
+
+    def _download_file(
+        self, url: str, target_dir: str, name: str
+    ) -> str | None:
+        """Download a single file. Returns the file path or None."""
+        os.makedirs(target_dir, exist_ok=True)
+
+        # Derive filename from URL or name
+        filename = url.rsplit("/", 1)[-1] if "/" in url else f"{name}.pdf"
+        file_path = os.path.join(target_dir, filename)
+
+        if os.path.exists(file_path):
+            return file_path
+
+        try:
+            resp = self.session.get(url, stream=True, timeout=config.REQUEST_TIMEOUT)
+            resp.raise_for_status()
+            with open(file_path, "wb") as f:
+                for chunk in resp.iter_content(chunk_size=8192):
+                    f.write(chunk)
+            print(f"  [+] Downloaded: {filename}")
+            time.sleep(config.DELAY_BETWEEN_REQUESTS)
+            return file_path
+        except requests.RequestException as e:
+            print(f"  [!] Failed to download {name}: {e}")
+            return None

--- a/apps/pipeline/pipeline/scrapers/static_html.py
+++ b/apps/pipeline/pipeline/scrapers/static_html.py
@@ -1,0 +1,226 @@
+"""Static HTML scraper for municipalities with simple HTML meeting pages."""
+
+import os
+import re
+import time
+from datetime import date, datetime
+from urllib.parse import urljoin, urlparse
+
+import requests
+from bs4 import BeautifulSoup
+
+from pipeline import config
+from pipeline.scrapers.base import (
+    BaseScraper,
+    MunicipalityConfig,
+    ScrapedDocument,
+    ScrapedMeeting,
+)
+
+
+class StaticHtmlScraper(BaseScraper):
+    """Scraper for municipalities that publish meetings as static HTML pages.
+
+    Parses an index page for meeting entries and follows links to download
+    PDF documents. Configurable via CSS selectors in source_config.
+
+    Expected source_config:
+        {
+            "type": "static_html",
+            "base_url": "https://www.rdos.bc.ca",
+            "index_url": "https://www.rdos.bc.ca/meetings/",
+            "selectors": {
+                "meeting_list": ".meeting-list .meeting-item",
+                "date": ".meeting-date",
+                "title": ".meeting-title",
+                "links": "a[href$='.pdf']"
+            },
+            "date_format": "%B %d, %Y",
+            "video_source": {"type": "youtube", "channel": "RDOS"}
+        }
+    """
+
+    def __init__(self, municipality: MunicipalityConfig):
+        super().__init__(municipality)
+        self.base_url = self.source_config.get("base_url", "")
+        self.index_url = self.source_config.get("index_url", "")
+        self.selectors = self.source_config.get("selectors", {})
+        self.date_format = self.source_config.get("date_format", "%B %d, %Y")
+
+        if not self.index_url:
+            raise ValueError(
+                f"Static HTML scraper requires 'index_url' in source_config for {municipality.slug}"
+            )
+
+        self.session = requests.Session()
+        self.session.headers.update(
+            {"User-Agent": config.USER_AGENT, "Accept": "text/html"}
+        )
+
+    def discover_meetings(
+        self, since_date: date | None = None
+    ) -> list[ScrapedMeeting]:
+        """Parse the index page for meeting entries."""
+        try:
+            resp = self.session.get(
+                self.index_url, timeout=config.REQUEST_TIMEOUT
+            )
+            resp.raise_for_status()
+        except requests.RequestException as e:
+            print(f"  [!] Failed to fetch index page {self.index_url}: {e}")
+            return []
+
+        soup = BeautifulSoup(resp.text, "html.parser")
+        meeting_selector = self.selectors.get("meeting_list", ".meeting-item")
+        date_selector = self.selectors.get("date", ".date")
+        title_selector = self.selectors.get("title", ".title")
+        link_selector = self.selectors.get("links", "a[href$='.pdf']")
+
+        items = soup.select(meeting_selector)
+        meetings = []
+
+        for item in items:
+            # Extract date
+            date_el = item.select_one(date_selector)
+            if not date_el:
+                continue
+
+            meeting_date = self._parse_date(date_el.get_text(strip=True))
+            if not meeting_date:
+                continue
+
+            if since_date and meeting_date < since_date:
+                continue
+
+            # Extract title
+            title_el = item.select_one(title_selector)
+            title = title_el.get_text(strip=True) if title_el else "Meeting"
+
+            # Extract document links
+            documents = []
+            for link in item.select(link_selector):
+                href = link.get("href", "")
+                if href:
+                    full_url = urljoin(self.base_url, href)
+                    link_text = link.get_text(strip=True) or os.path.basename(
+                        urlparse(href).path
+                    )
+
+                    # Guess category from link text
+                    category = None
+                    text_lower = link_text.lower()
+                    if "agenda" in text_lower:
+                        category = "Agenda"
+                    elif "minute" in text_lower:
+                        category = "Minutes"
+
+                    documents.append(
+                        ScrapedDocument(
+                            title=link_text,
+                            url=full_url,
+                            category=category,
+                            file_format="pdf",
+                        )
+                    )
+
+            meeting = ScrapedMeeting(
+                date=meeting_date,
+                title=title,
+                meeting_type=self._guess_meeting_type(title),
+                organization_name=self.municipality.name,
+                agenda_url=next(
+                    (d.url for d in documents if d.category == "Agenda"), None
+                ),
+                minutes_url=next(
+                    (d.url for d in documents if d.category == "Minutes"), None
+                ),
+                documents=documents,
+            )
+            meetings.append(meeting)
+
+        print(
+            f"  [StaticHTML] Discovered {len(meetings)} meeting(s) from {self.index_url}"
+        )
+        return meetings
+
+    def download_documents(
+        self, meeting: ScrapedMeeting, target_dir: str
+    ) -> list[str]:
+        """Download meeting documents to target_dir."""
+        os.makedirs(target_dir, exist_ok=True)
+        downloaded = []
+
+        for doc in meeting.documents:
+            if not doc.url:
+                continue
+
+            # Organize by category
+            if doc.category:
+                subfolder = os.path.join(target_dir, doc.category)
+            else:
+                subfolder = target_dir
+            os.makedirs(subfolder, exist_ok=True)
+
+            filename = os.path.basename(urlparse(doc.url).path) or f"{doc.title}.pdf"
+            file_path = os.path.join(subfolder, filename)
+
+            if os.path.exists(file_path):
+                downloaded.append(file_path)
+                continue
+
+            try:
+                resp = self.session.get(
+                    doc.url, stream=True, timeout=config.REQUEST_TIMEOUT
+                )
+                resp.raise_for_status()
+                with open(file_path, "wb") as f:
+                    for chunk in resp.iter_content(chunk_size=8192):
+                        f.write(chunk)
+                print(f"  [+] Downloaded: {filename}")
+                downloaded.append(file_path)
+                time.sleep(config.DELAY_BETWEEN_REQUESTS)
+            except requests.RequestException as e:
+                print(f"  [!] Failed to download {doc.title}: {e}")
+
+        return downloaded
+
+    def _parse_date(self, text: str) -> date | None:
+        """Try to parse a date string using the configured format."""
+        # Try configured format first
+        try:
+            return datetime.strptime(text.strip(), self.date_format).date()
+        except ValueError:
+            pass
+
+        # Fallback: try common formats
+        for fmt in ("%Y-%m-%d", "%m/%d/%Y", "%d %B %Y", "%B %d, %Y"):
+            try:
+                return datetime.strptime(text.strip(), fmt).date()
+            except ValueError:
+                continue
+
+        # Last resort: regex for YYYY-MM-DD
+        match = re.search(r"(\d{4}-\d{2}-\d{2})", text)
+        if match:
+            try:
+                return datetime.strptime(match.group(1), "%Y-%m-%d").date()
+            except ValueError:
+                pass
+
+        return None
+
+    @staticmethod
+    def _guess_meeting_type(title: str) -> str | None:
+        """Guess the meeting type from the title."""
+        title_lower = title.lower()
+        if "council" in title_lower:
+            return "Regular Council"
+        if "committee of the whole" in title_lower or "cow" in title_lower:
+            return "Committee of the Whole"
+        if "public hearing" in title_lower:
+            return "Public Hearing"
+        if "board" in title_lower:
+            return "Board Meeting"
+        if "committee" in title_lower:
+            return "Committee"
+        return None

--- a/apps/pipeline/pipeline/video/__init__.py
+++ b/apps/pipeline/pipeline/video/__init__.py
@@ -1,0 +1,26 @@
+"""Video source clients.
+
+Currently supports:
+- VimeoClient: Full Vimeo API + yt-dlp integration
+- YouTubeClient: Stub for future YouTube support
+"""
+
+
+class YouTubeClient:
+    """Stub for YouTube video source. To be implemented for municipalities
+    that publish meeting recordings on YouTube (e.g. RDOS).
+
+    Expected source_config.video_source:
+        {"type": "youtube", "channel": "RDOS"}
+    """
+
+    def __init__(self, channel: str = ""):
+        self.channel = channel
+
+    def get_video_map(self, limit=None):
+        print(f"  [YouTube] Video sync not yet implemented (channel: {self.channel})")
+        return {}
+
+    def download_video(self, video_data, output_folder, **kwargs):
+        print("  [YouTube] Video download not yet implemented")
+        return None


### PR DESCRIPTION
## Summary
- Adds `LegistarScraper` — uses Legistar Web API (`webapi.legistar.com/v1/{client}/`) to discover meetings and download attachments
- Adds `StaticHtmlScraper` — parses configurable HTML index pages with CSS selectors to find meeting documents
- Auto-registers both scrapers (`legistar`, `static_html`) via `_register_builtin_scrapers()` in `__init__.py`
- Adds `YouTubeClient` stub in `pipeline/video/__init__.py` for municipalities using YouTube instead of Vimeo

## Test plan
- [x] All 15 existing tests pass (1 skipped — pre-existing)
- [x] Scraper registry contains all 3 types: `civicweb`, `legistar`, `static_html`
- [x] Import check: `from pipeline.scrapers.legistar import LegistarScraper`
- [x] Import check: `from pipeline.scrapers.static_html import StaticHtmlScraper`
- [x] `YouTubeClient` stub returns empty map gracefully
- [x] `beautifulsoup4` already in pyproject.toml dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)