### PR TITLE
Phase 3: Pipeline Refactoring — municipality_id, DB names, Legistar fast path

### DIFF
--- a/apps/pipeline/pipeline/ingestion/matter_matching.py
+++ b/apps/pipeline/pipeline/ingestion/matter_matching.py
@@ -194,8 +194,9 @@ class MatterMatcher:
     Loaded once per ingestion session with all matters cached in memory.
     """
 
-    def __init__(self, supabase_client):
+    def __init__(self, supabase_client, municipality_id=None):
         self.supabase = supabase_client
+        self.municipality_id = municipality_id or 1
         self.matters = []
         self.identifier_index = defaultdict(list)  # normalized_id -> [matter]
         self.address_index = defaultdict(list)  # normalized_addr -> [matter]
@@ -215,7 +216,7 @@ class MatterMatcher:
         )
 
     def _fetch_all_matters(self) -> list[dict]:
-        """Fetch all matters with pagination."""
+        """Fetch all matters for this municipality with pagination."""
         all_data = []
         page = 0
         page_size = 1000
@@ -223,6 +224,7 @@ class MatterMatcher:
             res = (
                 self.supabase.table("matters")
                 .select("id, title, identifier, status, category")
+                .eq("municipality_id", self.municipality_id)
                 .range(page * page_size, (page + 1) * page_size - 1)
                 .execute()
             )

--- a/apps/pipeline/pipeline/orchestrator.py
+++ b/apps/pipeline/pipeline/orchestrator.py
@@ -355,7 +355,11 @@ class Archiver:
             return
 
         supabase = create_client(config.SUPABASE_URL, supabase_key)
-        ingester = MeetingIngester(config.SUPABASE_URL, supabase_key, config.GEMINI_API_KEY)
+        municipality_id = self.municipality.id if self.municipality else 1
+        ingester = MeetingIngester(
+            config.SUPABASE_URL, supabase_key, config.GEMINI_API_KEY,
+            municipality_id=municipality_id,
+        )
         diarized_folders = diarized_folders or set()
 
         # Single-folder targeted mode


### PR DESCRIPTION
## Summary
- Threads `municipality_id` through the entire ingestion pipeline: `MeetingIngester`, `MatterMatcher`, organization/meeting/matter creation
- Loads canonical names from DB per municipality (via memberships → people), falling back to hardcoded `CANONICAL_NAMES` for View Royal
- Scopes organization lookups and matter matching by `municipality_id` to prevent cross-municipality collisions
- Adds `process_legistar_meeting()` fast path that directly ingests structured Legistar API data without AI refinement
- Updates `_normalize_archive_path()` to handle both legacy `viewroyal_archive/` and new `archive/slug/` paths
- `Archiver` passes `municipality.id` from config to the ingester

## Test plan
- [x] All 15 existing tests pass (1 skipped — pre-existing)
- [x] Import check for all modified modules
- [x] `MeetingIngester(municipality_id=1)` backward compatible
- [x] `MatterMatcher(municipality_id=1)` scopes fetch query
- [x] `process_legistar_meeting` method exists and is callable

🤖 Generated with [Claude Code](https://claude.com/claude-code)