### PR TITLE
Improve key statement extraction prompts

### DIFF
--- a/apps/pipeline/pipeline/ingestion/ai_refiner.py
+++ b/apps/pipeline/pipeline/ingestion/ai_refiner.py
@@ -126,6 +126,7 @@ class AgendaItemRecord(BaseModel):
     is_controversial: bool
     debate_summary: str | None
     key_quotes: list[KeyQuote]
+    key_statements: list[KeyStatement] = []
     discussion_start_time: float | None
     discussion_end_time: float | None
     motions: list[MotionRecord]


### PR DESCRIPTION
## Summary
- Add `KeyStatement` Pydantic model with nullable `speaker` field for correspondence/unclear attribution
- Limit extraction to 6 key statements per item, focusing on policy decisions, financial impacts, community concerns, and contentious positions
- Require exactly one speaker per statement — no combined names like "Tobias/Lemon"
- Require unique timestamps per statement from actual transcript segments (no copying a single timestamp to all)

## Test plan
- [ ] Run pipeline on a meeting with substantive debate and verify key statements have distinct timestamps and single speakers
- [ ] Verify procedural items produce no key statements

🤖 Generated with [Claude Code](https://claude.com/claude-code)