### PR TITLE
fix(web): thread municipality through service callers + fix waitUntil ref

### DIFF
--- a/apps/web/app/hooks/use-api.ts
+++ b/apps/web/app/hooks/use-api.ts
@@ -1,4 +1,6 @@
 import { useState, useEffect, useCallback } from "react";
+import { useRouteLoaderData } from "react-router";
+import type { Municipality } from "../lib/types";
 import * as meetingService from "../services/meetings";
 import * as peopleService from "../services/people";
 import * as orgService from "../services/organizations";
@@ -46,14 +48,18 @@ export function useQuery<T, Args extends any[]>(
  * Centralized API hook to access all data sources.
  */
 export function useApi() {
+  const rootData = useRouteLoaderData("root") as
+    | { municipality?: Municipality }
+    | undefined;
+  const municipality = rootData?.municipality as Municipality;
   return {
     meetings: {
       list: meetingService.getMeetings,
       get: meetingService.getMeetingById,
       useList: (options?: meetingService.GetMeetingsOptions) =>
-        useQuery(meetingService.getMeetings, supabase, options),
+        useQuery(meetingService.getMeetings, supabase, municipality, options),
       useGet: (id: string) =>
-        useQuery(meetingService.getMeetingById, supabase, id),
+        useQuery(meetingService.getMeetingById, supabase, municipality, id),
     },
     people: {
       list: peopleService.getPeopleWithStats,
@@ -71,10 +77,11 @@ export function useApi() {
       list: matterService.getMatters,
       get: matterService.getMatterById,
       getHotTopics: matterService.getHotTopics,
-      useList: () => useQuery(matterService.getMatters, supabase),
+      useList: () => useQuery(matterService.getMatters, supabase, municipality),
       useGet: (id: string) =>
-        useQuery(matterService.getMatterById, supabase, id),
-      useHotTopics: () => useQuery(matterService.getHotTopics, supabase),
+        useQuery(matterService.getMatterById, supabase, municipality, id),
+      useHotTopics: () =>
+        useQuery(matterService.getHotTopics, supabase, municipality),
     },
 
     search: {
@@ -105,7 +112,7 @@ export function useApi() {
     decisions: {
       getDivided: meetingService.getDividedDecisions,
       useDivided: () =>
-        useQuery(meetingService.getDividedDecisions, supabase),
+        useQuery(meetingService.getDividedDecisions, supabase, municipality),
     },
   };
 }

--- a/apps/web/app/routes/api.ask.tsx
+++ b/apps/web/app/routes/api.ask.tsx
@@ -38,7 +38,13 @@ function getClientIP(request: Request): string {
 }
 
 // Helper to create the streaming response
-function createStreamingResponse(question: string, context?: string, municipalityName?: string, clientIP?: string) {
+function createStreamingResponse(
+  question: string,
+  context?: string,
+  municipalityName?: string,
+  clientIP?: string,
+  waitUntil?: (promise: Promise<any>) => void,
+) {
   const stream = new ReadableStream({
     async start(controller) {
       const encoder = new TextEncoder();
@@ -160,7 +166,8 @@ function createStreamingResponse(question: string, context?: string, municipalit
   });
 }
 
-export async function action({ request }: Route.ActionArgs) {
+export async function action({ request, context: actionContext }: Route.ActionArgs) {
+  const waitUntil = actionContext.cloudflare?.ctx?.waitUntil?.bind(actionContext.cloudflare.ctx);
   if (request.method !== "POST") {
     return new Response("Method Not Allowed", { status: 405 });
   }
@@ -178,7 +185,7 @@ export async function action({ request }: Route.ActionArgs) {
 
   const { supabase } = createSupabaseServerClient(request);
   const municipality = await getMunicipality(supabase);
-  return createStreamingResponse(question, context, municipality.name, getClientIP(request));
+  return createStreamingResponse(question, context, municipality.name, getClientIP(request), waitUntil);
 }
 
 // Also support GET for simple queries
@@ -223,5 +230,5 @@ export async function loader({ request, context: loaderContext }: Route.LoaderAr
 
   const { supabase } = createSupabaseServerClient(request);
   const municipality = await getMunicipality(supabase);
-  return createStreamingResponse(question, context, municipality.name, getClientIP(request));
+  return createStreamingResponse(question, context, municipality.name, getClientIP(request), waitUntil);
 }

--- a/apps/web/app/routes/matter-detail.tsx
+++ b/apps/web/app/routes/matter-detail.tsx
@@ -1,6 +1,7 @@
 import type { Route } from "./+types/matter-detail";
 import { getMatterById, getDocumentsForAgendaItems } from "../services/matters";
 import { getSupabaseAdminClient } from "../lib/supabase.server";
+import { getMunicipality } from "../services/municipality";
 import { Link } from "react-router";
 import { SubscribeButton } from "../components/subscribe-button";
 import { ogImageUrl, ogUrl } from "../lib/og";
@@ -67,11 +68,12 @@ export async function loader({ params }: Route.LoaderArgs) {
 
   try {
     const supabase = getSupabaseAdminClient();
-    const matter = await getMatterById(supabase, id);
+    const municipality = await getMunicipality(supabase);
+    const matter = await getMatterById(supabase, municipality, id);
 
     // Fetch documents for all agenda items in this matter (batch query)
     const agendaItemIds = (matter.agenda_items || []).map((ai) => ai.id);
-    const matterDocuments = await getDocumentsForAgendaItems(supabase, agendaItemIds);
+    const matterDocuments = await getDocumentsForAgendaItems(supabase, municipality, agendaItemIds);
 
     return { matter, matterDocuments };
   } catch (error) {

--- a/apps/web/app/routes/matters.tsx
+++ b/apps/web/app/routes/matters.tsx
@@ -1,6 +1,7 @@
 import type { Route } from "./+types/matters";
 import { getMatters } from "../services/matters";
 import { getSupabaseAdminClient } from "../lib/supabase.server";
+import { getMunicipality } from "../services/municipality";
 import { Link, useRouteLoaderData } from "react-router";
 import type { Municipality } from "../lib/types";
 import {
@@ -42,7 +43,8 @@ export const meta: Route.MetaFunction = () => {
 export async function loader() {
   try {
     const supabase = getSupabaseAdminClient();
-    const matters = await getMatters(supabase);
+    const municipality = await getMunicipality(supabase);
+    const matters = await getMatters(supabase, municipality);
     return { matters };
   } catch (error) {
     console.error("Error fetching matters:", error);

--- a/apps/web/app/routes/meeting-detail.tsx
+++ b/apps/web/app/routes/meeting-detail.tsx
@@ -149,11 +149,11 @@ export async function loader({ params, request }: Route.LoaderArgs) {
 
   try {
     const { supabase } = createSupabaseServerClient(request);
-    const [data, documentSections, extractedDocuments, municipality] = await Promise.all([
-      getMeetingById(supabase, id),
-      getDocumentSectionsForMeeting(supabase, id),
-      getExtractedDocumentsForMeeting(supabase, id),
-      getMunicipality(supabase).catch(() => null),
+    const municipality = await getMunicipality(supabase);
+    const [data, documentSections, extractedDocuments] = await Promise.all([
+      getMeetingById(supabase, municipality, id),
+      getDocumentSectionsForMeeting(supabase, municipality, id),
+      getExtractedDocumentsForMeeting(supabase, municipality, id),
     ]);
 
     // Only show attendance info for future meetings (Vancouver timezone)

--- a/apps/web/app/routes/meeting-documents.tsx
+++ b/apps/web/app/routes/meeting-documents.tsx
@@ -1,6 +1,7 @@
 import type { Route } from "./+types/meeting-documents";
 import { getSupabaseAdminClient } from "../lib/supabase.server";
 import { getExtractedDocumentsForMeeting } from "../services/meetings";
+import { getMunicipality } from "../services/municipality";
 import { Link } from "react-router";
 import type { ExtractedDocument } from "../lib/types";
 import {
@@ -40,6 +41,7 @@ export async function loader({ params }: Route.LoaderArgs) {
   if (!meetingId) throw new Response("Missing params", { status: 400 });
 
   const supabase = getSupabaseAdminClient();
+  const municipality = await getMunicipality(supabase);
 
   const [meetingRes, docsRes, extractedDocs] = await Promise.all([
     supabase
@@ -52,7 +54,7 @@ export async function loader({ params }: Route.LoaderArgs) {
       .select("id, title, category, source_url, page_count")
       .eq("meeting_id", meetingId)
       .order("title"),
-    getExtractedDocumentsForMeeting(supabase, meetingId),
+    getExtractedDocumentsForMeeting(supabase, municipality, meetingId),
   ]);
 
   if (meetingRes.error || !meetingRes.data)

--- a/apps/web/app/routes/meeting-explorer.tsx
+++ b/apps/web/app/routes/meeting-explorer.tsx
@@ -1,6 +1,7 @@
 import type { Route } from "./+types/meeting-explorer";
 import { getMeetingById } from "../services/meetings";
 import { getSupabaseAdminClient } from "../lib/supabase.server";
+import { getMunicipality } from "../services/municipality";
 import { Link, useSearchParams } from "react-router";
 import { useState, useMemo, useRef } from "react";
 import {
@@ -63,7 +64,8 @@ export async function loader({ params }: Route.LoaderArgs) {
   const { id } = params;
   try {
     const supabase = getSupabaseAdminClient();
-    const data = await getMeetingById(supabase, id);
+    const municipality = await getMunicipality(supabase);
+    const data = await getMeetingById(supabase, municipality, id);
     return data;
   } catch (error: any) {
     if (error.message === "Meeting Not Found") {

--- a/apps/web/app/routes/meetings.tsx
+++ b/apps/web/app/routes/meetings.tsx
@@ -1,6 +1,7 @@
 import type { Route } from "./+types/meetings";
 import { getMeetings } from "../services/meetings";
 import { getSupabaseAdminClient } from "../lib/supabase.server";
+import { getMunicipality } from "../services/municipality";
 import { getMunicipalityFromMatches } from "../lib/municipality-helpers";
 import type { Meeting } from "../lib/types";
 import { cn } from "../lib/utils";
@@ -61,7 +62,8 @@ export async function loader({ request }: Route.LoaderArgs) {
 
   try {
     const supabase = getSupabaseAdminClient();
-    const { meetings, statsMap } = await getMeetings(supabase, {
+    const municipality = await getMunicipality(supabase);
+    const { meetings, statsMap } = await getMeetings(supabase, municipality, {
       startDate: `${selectedYear}-01-01`,
       endDate: `${selectedYear}-12-31`,
     });

--- a/apps/web/app/routes/speaker-alias.tsx
+++ b/apps/web/app/routes/speaker-alias.tsx
@@ -42,6 +42,7 @@ import {
 import { cn } from "../lib/utils";
 import { getVimeoVideoData } from "../services/vimeo.server";
 import { getMeetingById } from "../services/meetings";
+import { getMunicipality } from "../services/municipality";
 import { useVideoPlayer } from "../hooks/useVideoPlayer";
 
 // Types
@@ -124,7 +125,8 @@ export async function loader({ request }: { request: Request }) {
       // 4. Fetch Meeting Details (Transcript & Aliases) via Service
       try {
         const adminClient = getSupabaseAdminClient();
-        const meetingData = await getMeetingById(adminClient, meetingId);
+        const municipality = await getMunicipality(adminClient);
+        const meetingData = await getMeetingById(adminClient, municipality, meetingId);
         aliases = meetingData.speakerAliases;
 
         // Create alias map for fallback

--- a/apps/web/tests/services/meetings.test.ts
+++ b/apps/web/tests/services/meetings.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { getMeetings, getMeetingById } from "~/services/meetings";
 import type { GetMeetingsOptions } from "~/services/meetings";
+import type { Municipality } from "~/lib/types";
+
+// Minimal municipality stub — services only read `.id` for scoping.
+const mockMunicipality = { id: 1 } as unknown as Municipality;
 
 // Helper to create a chainable mock Supabase query builder
 function createMockQueryBuilder(returnData: any = [], returnError: any = null) {
@@ -43,7 +47,7 @@ describe("getMeetings", () => {
     const builder = createMockQueryBuilder([]);
     const supabase = createMockSupabase({ meetings: builder });
 
-    await getMeetings(supabase);
+    await getMeetings(supabase, mockMunicipality);
 
     expect(supabase.from).toHaveBeenCalledWith("meetings");
     expect(builder.select).toHaveBeenCalledWith(
@@ -55,7 +59,7 @@ describe("getMeetings", () => {
     const builder = createMockQueryBuilder([]);
     const supabase = createMockSupabase({ meetings: builder });
 
-    await getMeetings(supabase);
+    await getMeetings(supabase, mockMunicipality);
 
     const selectString = builder.select.mock.calls[0][0];
     expect(selectString).not.toContain("neighborhood");
@@ -65,7 +69,7 @@ describe("getMeetings", () => {
     const builder = createMockQueryBuilder([]);
     const supabase = createMockSupabase({ meetings: builder });
 
-    await getMeetings(supabase);
+    await getMeetings(supabase, mockMunicipality);
 
     expect(builder.order).toHaveBeenCalledWith("meeting_date", {
       ascending: false,
@@ -76,7 +80,7 @@ describe("getMeetings", () => {
     const builder = createMockQueryBuilder([]);
     const supabase = createMockSupabase({ meetings: builder });
 
-    await getMeetings(supabase, {
+    await getMeetings(supabase, mockMunicipality, {
       orderBy: "title",
       orderDirection: "asc",
     });
@@ -88,7 +92,7 @@ describe("getMeetings", () => {
     const builder = createMockQueryBuilder([]);
     const supabase = createMockSupabase({ meetings: builder });
 
-    await getMeetings(supabase, { limit: 10 });
+    await getMeetings(supabase, mockMunicipality, { limit: 10 });
 
     expect(builder.limit).toHaveBeenCalledWith(10);
   });
@@ -97,7 +101,7 @@ describe("getMeetings", () => {
     const builder = createMockQueryBuilder([]);
     const supabase = createMockSupabase({ meetings: builder });
 
-    await getMeetings(supabase);
+    await getMeetings(supabase, mockMunicipality);
 
     expect(builder.limit).not.toHaveBeenCalled();
   });
@@ -106,7 +110,7 @@ describe("getMeetings", () => {
     const builder = createMockQueryBuilder([]);
     const supabase = createMockSupabase({ meetings: builder });
 
-    await getMeetings(supabase, { status: "published" });
+    await getMeetings(supabase, mockMunicipality, { status: "published" });
 
     expect(builder.eq).toHaveBeenCalledWith("status", "published");
   });
@@ -115,7 +119,7 @@ describe("getMeetings", () => {
     const builder = createMockQueryBuilder([]);
     const supabase = createMockSupabase({ meetings: builder });
 
-    await getMeetings(supabase, { organization_id: 5 });
+    await getMeetings(supabase, mockMunicipality, { organization_id: 5 });
 
     expect(builder.eq).toHaveBeenCalledWith("organization_id", 5);
   });
@@ -124,7 +128,7 @@ describe("getMeetings", () => {
     const builder = createMockQueryBuilder([]);
     const supabase = createMockSupabase({ meetings: builder });
 
-    await getMeetings(supabase, { has_transcript: true });
+    await getMeetings(supabase, mockMunicipality, { has_transcript: true });
 
     expect(builder.eq).toHaveBeenCalledWith("has_transcript", true);
   });
@@ -133,7 +137,7 @@ describe("getMeetings", () => {
     const builder = createMockQueryBuilder([]);
     const supabase = createMockSupabase({ meetings: builder });
 
-    await getMeetings(supabase, {
+    await getMeetings(supabase, mockMunicipality, {
       startDate: "2025-01-01",
       endDate: "2025-12-31",
     });
@@ -146,7 +150,7 @@ describe("getMeetings", () => {
     const builder = createMockQueryBuilder([]);
     const supabase = createMockSupabase({ meetings: builder });
 
-    await getMeetings(supabase, {
+    await getMeetings(supabase, mockMunicipality, {
       status: "published",
       has_transcript: true,
       limit: 5,
@@ -163,7 +167,7 @@ describe("getMeetings", () => {
     const builder = createMockQueryBuilder(null);
     const supabase = createMockSupabase({ meetings: builder });
 
-    const result = await getMeetings(supabase);
+    const result = await getMeetings(supabase, mockMunicipality);
 
     expect(result.meetings).toEqual([]);
     expect(result.statsMap).toEqual({});
@@ -177,7 +181,7 @@ describe("getMeetings", () => {
     const builder = createMockQueryBuilder(mockMeetings);
     const supabase = createMockSupabase({ meetings: builder });
 
-    const result = await getMeetings(supabase);
+    const result = await getMeetings(supabase, mockMunicipality);
 
     expect(result.meetings).toEqual(mockMeetings);
   });
@@ -188,7 +192,7 @@ describe("getMeetings", () => {
     });
     const supabase = createMockSupabase({ meetings: builder });
 
-    await expect(getMeetings(supabase)).rejects.toThrow(
+    await expect(getMeetings(supabase, mockMunicipality)).rejects.toThrow(
       "Database connection error",
     );
   });
@@ -197,7 +201,7 @@ describe("getMeetings", () => {
     const builder = createMockQueryBuilder([]);
     const supabase = createMockSupabase({ meetings: builder });
 
-    await getMeetings(supabase);
+    await getMeetings(supabase, mockMunicipality);
 
     const selectString = builder.select.mock.calls[0][0] as string;
     const expectedColumns = [
@@ -260,7 +264,7 @@ describe("getMeetingById", () => {
       }),
     } as any;
 
-    await getMeetingById(supabase, "1");
+    await getMeetingById(supabase, mockMunicipality, "1");
 
     expect(supabase.from).toHaveBeenCalledWith("meetings");
     expect(meetingBuilder.eq).toHaveBeenCalledWith("id", "1");
@@ -294,7 +298,7 @@ describe("getMeetingById", () => {
       }),
     } as any;
 
-    await expect(getMeetingById(supabase, "999")).rejects.toThrow(
+    await expect(getMeetingById(supabase, mockMunicipality, "999")).rejects.toThrow(
       "Meeting Not Found",
     );
   });
@@ -334,7 +338,7 @@ describe("getMeetingById", () => {
       }),
     } as any;
 
-    await getMeetingById(supabase, "1");
+    await getMeetingById(supabase, mockMunicipality, "1");
 
     expect(supabase.from).toHaveBeenCalledWith("agenda_items");
     expect(agendaBuilder.eq).toHaveBeenCalledWith("meeting_id", "1");
@@ -379,7 +383,7 @@ describe("getMeetingById", () => {
       }),
     } as any;
 
-    const result = await getMeetingById(supabase, "1");
+    const result = await getMeetingById(supabase, mockMunicipality, "1");
 
     expect(result).toHaveProperty("meeting");
     expect(result).toHaveProperty("agendaItems");


### PR DESCRIPTION
## Problem
The website was throwing runtime errors. Root cause: commit `85531e59 (feat 41-01)` changed `getMeetings`/`getMeetingById`/`getMatters`/`getMatterById`/`getDocumentsForAgendaItems` and the document fetchers to require a `Municipality` argument, but **never updated the callers**. Every meeting/matter page loader passed the wrong positional args, crashing at runtime (`Cannot read properties of undefined (reading 'id')`). The predeploy test suite correctly caught this and blocked deploys.

A second, pre-existing bug: `createStreamingResponse` in `api.ask.tsx` referenced an **undeclared `waitUntil`** variable → `ReferenceError` in the RAG streaming handler.

## Fix
- Thread `municipality` (via `getMunicipality(supabase)`) through 7 route loaders: meetings, meeting-detail, meeting-explorer, meeting-documents, matters, matter-detail, speaker-alias.
- Source `municipality` from root loader data (`useRouteLoaderData("root")`) in `use-api.ts` hooks.
- Pass `waitUntil` into `createStreamingResponse` from both `action` and `loader` in `api.ask.tsx`.
- Update stale `meetings` service test to the new signature.

## Verification
- `pnpm vitest run` → 199/199 pass
- `pnpm typecheck` → 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)