### PR TITLE
chore(pipeline): bump yt-dlp floor for Vimeo downloads

### DIFF
--- a/apps/pipeline/pyproject.toml
+++ b/apps/pipeline/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "supabase>=2.27.2",
     "surya-ocr>=0.13.1",
     "tqdm>=4.67.1",
-    "yt-dlp>=2025.12.8",
+    "yt-dlp>=2026.6.9",
 ]
 
 [tool.uv.sources]


### PR DESCRIPTION
## What
Bumps the `yt-dlp` floor in `apps/pipeline/pyproject.toml` from `>=2025.12.8` to `>=2026.6.9`.

## Why
A stale yt-dlp (`2026.02.04`) silently broke Vimeo audio downloads in the pipeline — the extractor returned `HTTP 404` on the watch page / `No video formats found` after Vimeo changed their player. This blocked transcription of newly-ingested meetings (e.g. May 12 & May 19 2026), which showed no transcript on the site.

Upgrading yt-dlp resolved it immediately (both videos went from 0 → 23 formats with audio). It was **not** a Vimeo token or cookie issue — the token returns `200` and cookies were valid.

`uv.lock` is gitignored, so the manifest floor is the durable pin that makes a fresh `uv lock` resolve to a working version on other machines/CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)